### PR TITLE
Implement AI scientist mechanism for chromaworks compatibility

### DIFF
--- a/GameData/AutomaticLabHousekeeper/AutomaticLabHousekeeper.version
+++ b/GameData/AutomaticLabHousekeeper/AutomaticLabHousekeeper.version
@@ -10,7 +10,7 @@
   "VERSION": {
     "MAJOR": 1,
     "MINOR": 0,
-    "PATCH": 3,
+    "PATCH": 4,
     "BUILD": 0
   },
   "KSP_VERSION": {

--- a/GameData/AutomaticLabHousekeeper/Localization/de_de.cfg
+++ b/GameData/AutomaticLabHousekeeper/Localization/de_de.cfg
@@ -7,6 +7,7 @@ Localization
 		
 		//Angezeigte Nachricht
 		#autoLOC_ALH_0003 = F&E : <<1>> Wissenschaft erhalten von <<2>>
+                #autoLOC_ALH_0031 = F&E: nzureichende elektrische Energie (<<2>>/<<1>>) auf <<3>>. Wird übersprungen…
 
                 //VAB/SPH Beschreibung
                 #autoLOC_ALH_0004 = Hat die Fähigkeit automatisch Wissenschaft an F&E zu senden.\n

--- a/GameData/AutomaticLabHousekeeper/Localization/en_us.cfg
+++ b/GameData/AutomaticLabHousekeeper/Localization/en_us.cfg
@@ -7,6 +7,7 @@ Localization
 		
 		//Transmission ScreenMessage
 		#autoLOC_ALH_0003 = R&D: Received <<1>> science from <<2>>
+                #autoLOC_ALH_0031 = R&D: Insufficient EC (<<2>>/<<1>>) on <<3>>. Skipping transfer..
 
                 //VAB/SPH Description
                 #autoLOC_ALH_0004 = Has ability to automatically transfer processed science to R&D over time.\n

--- a/source/AutomaticLabHousekeeper/ALH_Main.cs
+++ b/source/AutomaticLabHousekeeper/ALH_Main.cs
@@ -172,7 +172,7 @@ namespace ALH
 
                         if (transmissionEnabled)
                         {
-                            TransferScienceFromLab(vessel, part, lab);
+                            TransferScienceFromLab(vessel, part, lab, alhModule);
                         }
 
                         if (dataPullingEnabled)
@@ -197,7 +197,7 @@ namespace ALH
                         if (transmissionEnabled)
                         {
                             SimulateScienceProcessingForUnloadedLab(vessel, protoPart, labModule, converterModule);
-                            TransferScienceFromUnloadedLab(vessel, protoPart, labModule);
+                            TransferScienceFromUnloadedLab(vessel, protoPart, labModule, alhModule);
                         }
 
                         if (dataPullingEnabled)
@@ -236,49 +236,90 @@ namespace ALH
             return true;
         }
 
-        void TransferScienceFromLab(Vessel vessel, Part part, ModuleScienceLab lab)
+        void TransferScienceFromLab(Vessel vessel, Part part, ModuleScienceLab lab, PartModule alhModule)
         {
             Debug.Log($"[AutomaticLabHousekeeper] Processing science transfer for lab {part.partName} in LOADED vessel {vessel.vesselName}");
-
-            if (lab.storedScience >= 1)
+            float ecPerMit = GetECPerMit(alhModule);
+            if (ecPerMit < 0)
             {
-                float wholeScience = Mathf.Floor(lab.storedScience);
-                float remainingScience = lab.storedScience - wholeScience;
-
-                Debug.Log($"[AutomaticLabHousekeeper] Transferring {wholeScience} science from {vessel.vesselName} to R&D, keeping {remainingScience} science in the lab");
-
-                ResearchAndDevelopment.Instance.AddScience(wholeScience, TransactionReasons.ScienceTransmission);
-                lab.storedScience = remainingScience;
-
-                ScreenMessages.PostScreenMessage(Localizer.Format("#autoLOC_ALH_0003", wholeScience, vessel.vesselName), 10f, ScreenMessageStyle.UPPER_CENTER);
+                Debug.LogWarning($"[AutomaticLabHousekeeper] Invalid ecPerMit value ({ecPerMit}) in ALH module on {part.partName}. Skipping science transfer.");
             }
             else
             {
-                Debug.Log("[AutomaticLabHousekeeper] Not enough storedScience");
+                if (lab.storedScience >= 1)
+                {
+                    float wholeScience = Mathf.Floor(lab.storedScience);
+                    float remainingScience = lab.storedScience - wholeScience;
+                    float requiredEC = wholeScience * GetMitPerScience() * ecPerMit;
+                    double ecAvailable = getAvailableEC(vessel);
+
+                    if (ecAvailable < requiredEC)
+                    {
+                        Debug.Log($"[AutomaticLabHousekeeper] Not enough EC ({ecAvailable:F1} / {requiredEC:F1}) for science transfer on {vessel.vesselName}");
+                        ScreenMessages.PostScreenMessage(Localizer.Format("#autoLOC_ALH_0031", requiredEC, ecAvailable, vessel.vesselName), 10f, ScreenMessageStyle.UPPER_CENTER);
+                    }
+                    else
+                    {
+                        DebugLog($"[AutomaticLabHousekeeper] Sufficient EC ({ecAvailable:F1} / {requiredEC:F1}) for science transfer on {vessel.vesselName}");
+                        // Consume EC
+                        double ecTaken = vessel.rootPart.RequestResource("ElectricCharge", (double)requiredEC);
+                        DebugLog($"[AutomaticLabHousekeeper] Consumed {ecTaken:F2} EC for transmitting {wholeScience} science from {vessel.vesselName}");
+                        DebugLog($"[AutomaticLabHousekeeper] Transferring {wholeScience} science from {vessel.vesselName} to R&D, keeping {remainingScience} science in the lab");
+                        // Add science to R&D and update lab storage
+                        ResearchAndDevelopment.Instance.AddScience(wholeScience, TransactionReasons.ScienceTransmission);
+                        lab.storedScience = remainingScience;
+
+                        ScreenMessages.PostScreenMessage(Localizer.Format("#autoLOC_ALH_0003", wholeScience, vessel.vesselName), 10f, ScreenMessageStyle.UPPER_CENTER);
+                    }
+
+
+                }
+                else
+                {
+                    Debug.Log("[AutomaticLabHousekeeper] Not enough storedScience");
+                }
             }
         }
 
-        void TransferScienceFromUnloadedLab(Vessel vessel, ProtoPartSnapshot protoPart, ProtoPartModuleSnapshot labModule)
+        void TransferScienceFromUnloadedLab(Vessel vessel, ProtoPartSnapshot protoPart, ProtoPartModuleSnapshot labModule, ProtoPartModuleSnapshot alhModule)
         {
             Debug.Log($"[AutomaticLabHousekeeper] Processing science transfer for lab {protoPart.partName} in UNLOADED vessel {vessel.vesselName}");
-
-            float storedScience = float.Parse(labModule.moduleValues.GetValue("storedScience"));
-
-            if (storedScience >= 1)
+            float ecPerMit = GetECPerMit(alhModule);
+            if (ecPerMit < 0)
             {
-                float wholeScience = Mathf.Floor(storedScience);
-                float remainingScience = storedScience - wholeScience;
-
-                Debug.Log($"[AutomaticLabHousekeeper] Transferring {wholeScience} science from {vessel.vesselName} to R&D, keeping {remainingScience} science in the lab");
-
-                ResearchAndDevelopment.Instance.AddScience(wholeScience, TransactionReasons.ScienceTransmission);
-                labModule.moduleValues.SetValue("storedScience", remainingScience.ToString("F2"));
-
-                ScreenMessages.PostScreenMessage(Localizer.Format("#autoLOC_ALH_0003", wholeScience, vessel.vesselName), 10f, ScreenMessageStyle.UPPER_CENTER);
+                Debug.LogWarning($"[AutomaticLabHousekeeper] Invalid ecPerMit value ({ecPerMit}) in ALH module on {protoPart.partName}. Skipping science transfer.");
             }
             else
             {
-                Debug.Log("[AutomaticLabHousekeeper] Not enough storedScience");
+                float storedScience = float.Parse(labModule.moduleValues.GetValue("storedScience"));
+                if (storedScience >= 1)
+                {
+                    float wholeScience = Mathf.Floor(storedScience);
+                    float remainingScience = storedScience - wholeScience;
+                    float requiredEC = wholeScience * GetMitPerScience() * ecPerMit;
+                    double ecAvailable = getAvailableEC(vessel);
+
+                    if (ecAvailable < requiredEC)
+                    {
+                        Debug.Log($"[AutomaticLabHousekeeper] Not enough EC ({ecAvailable:F1} / {requiredEC:F1}) for science transfer on {vessel.vesselName} (UNLOADED)");
+                        ScreenMessages.PostScreenMessage(Localizer.Format("#autoLOC_ALH_0031", requiredEC, ecAvailable, vessel.vesselName), 10f, ScreenMessageStyle.UPPER_CENTER);
+                    }
+                    else
+                    {
+                        DebugLog($"[AutomaticLabHousekeeper] Sufficient EC ({ecAvailable:F1} / {requiredEC:F1}) for science transfer on {vessel.vesselName} (UNLOADED)");
+                        DebugLog($"[AutomaticLabHousekeeper] Transferring {wholeScience} science from {vessel.vesselName} to R&D, keeping {remainingScience} science in the lab");
+                        // For unloaded, we cannot request EC, so we just check
+                        // Add science to R&D and update lab storage
+                        ResearchAndDevelopment.Instance.AddScience(wholeScience, TransactionReasons.ScienceTransmission);
+                        labModule.moduleValues.SetValue("storedScience", remainingScience.ToString("F2"));
+
+                        ScreenMessages.PostScreenMessage(Localizer.Format("#autoLOC_ALH_0003", wholeScience, vessel.vesselName), 10f, ScreenMessageStyle.UPPER_CENTER);
+                    }
+                }
+                else
+                {
+                    Debug.Log("[AutomaticLabHousekeeper] Not enough storedScience");
+                }
             }
         }
 
@@ -449,7 +490,7 @@ namespace ALH
                 }
             }
             return Mathf.Max(totalLevel, 0.0f);
-    }
+        }
 
         void PullDataIntoLab(Vessel vessel, Part part, Module_AutomaticLabHousekeeper alhModule)
         {
@@ -666,5 +707,78 @@ namespace ALH
                 Debug.Log($"{message}");
             }
         }
+
+        // Helper method to get mitPerScience (inverse of science per MB)
+        private float GetMitPerScience()
+        {
+            return 1f; // Vanilla KSP uses 1 Mit per Science by default
+            //TODO: Add support for mods that change this ratio
+        }
+
+        private double getAvailableEC(Vessel vessel)
+        {
+            if (vessel == null)
+            {
+                Debug.LogError("[AutomaticLabHousekeeper] getAvailableEC called with null vessel.");
+                return -1;
+            }
+
+            double ecAvailable = 0;
+            if (vessel.loaded)
+            {
+                foreach (Part p in vessel.Parts)
+                {
+                    foreach (PartResource r in p.Resources)
+                    {
+                        if (r.resourceName == "ElectricCharge")
+                            ecAvailable += r.amount;
+                    }
+
+                }
+            }
+            else
+            {
+                    foreach (var PartSnap in vessel.protoVessel.protoPartSnapshots)
+                    {
+                        foreach (var res in PartSnap.resources)
+                        {
+                            if (res.resourceName == "ElectricCharge")
+                                ecAvailable += double.Parse(res.amount.ToString("F2"));
+                        }
+                    }
+            }
+
+            return ecAvailable;
+        }
+
+        private float GetECPerMit(object alhModule)
+        {
+            float ecPerMit = -1f; // fallback default
+            string value = null; 
+            switch (alhModule)
+            {
+                case Module_AutomaticLabHousekeeper loadedModule:
+                    value = loadedModule.ecPerMit;
+                    break;
+                case ProtoPartModuleSnapshot protoModule when protoModule.moduleValues.HasValue("ecPerMit"):
+                    value = protoModule.moduleValues.GetValue("ecPerMit");
+                    break;
+                default:
+                    Debug.LogWarning($"[AutomaticLabHousekeeper] GetECPerMit called with unknown alhModule type. Using fallback EC per Mit = {ecPerMit}");
+                    return ecPerMit;
+
+            }
+
+            if (!string.IsNullOrEmpty(value) && float.TryParse(value, out float ParsedEcPerMit))
+                return ParsedEcPerMit;
+            else
+            {
+                DebugLog($"[AutomaticLabHousekeeper] Failed to parse ecPerMit ('{value}'), using fallback -1");
+                return ecPerMit;                
+            }
+        }
     }
 }
+
+
+

--- a/source/AutomaticLabHousekeeper/ALH_Main.cs
+++ b/source/AutomaticLabHousekeeper/ALH_Main.cs
@@ -187,7 +187,7 @@ namespace ALH
                     {
                         ProtoPartModuleSnapshot labModule = protoPart.modules.FirstOrDefault(m => m.moduleName == "ModuleScienceLab");
                         ProtoPartModuleSnapshot alhModule = protoPart.modules.FirstOrDefault(m => m.moduleName == "Module_AutomaticLabHousekeeper");
-                        ProtoPartModuleSnapshot converterModule = protoPart.modules.FirstOrDefault(m => m.moduleName == "ModuleScienceConverter");
+                        ProtoPartModuleSnapshot converterModule = protoPart.modules.FirstOrDefault(m => m.moduleName == "ModuleScienceConverter" || m.moduleName == "CW_ModuleScienceConverter");
 
                         if (labModule == null || alhModule == null) continue;
 
@@ -305,7 +305,10 @@ namespace ALH
             }
 
             ConfigNode partConfig = PartLoader.getPartInfoByName(protoPart.partName).partConfig;
-            ConfigNode moduleNode = partConfig.GetNodes("MODULE").FirstOrDefault(n => n.GetValue("name") == "ModuleScienceConverter");
+            ConfigNode moduleNode = partConfig.GetNodes("MODULE")
+                .FirstOrDefault(n =>
+                    n.GetValue("name") == "ModuleScienceConverter" ||
+                    n.GetValue("name") == "CW_ModuleScienceConverter");
 
             float scienceCap = float.Parse(moduleNode.GetValue("scienceCap"));
             DebugLog($"[AutomaticLabHousekeeper] scienceCap {scienceCap}");
@@ -337,8 +340,19 @@ namespace ALH
             double currentTime = Planetarium.GetUniversalTime();
             double timeElapsed = currentTime - lastUpdateTime;
 
-            float totalScientistLevel = CalculateScientistLevel(protoPart, scientistBonus);
-            DebugLog($"[AutomaticLabHousekeeper] totalScientistValue {totalScientistLevel}");
+            float totalScientistLevel;
+            if (converterModule.moduleName == "CW_ModuleScienceConverter")
+            {
+                // Special handling for CW_ModuleScienceConverter
+                totalScientistLevel = GetAIScientistsLevel(vessel, protoPart, scientistBonus);
+                DebugLog($"[AutomaticLabHousekeeper] CW_ModuleScienceConverter détecté, totalScientistLevel : {totalScientistLevel}");
+            }
+            else
+            {
+                // Normal calculation based on crew
+                totalScientistLevel = CalculateScientistLevel(protoPart, scientistBonus);
+                DebugLog($"[AutomaticLabHousekeeper] ModuleScienceConverter détecté, totalAIScientistLevel calculé : {totalScientistLevel}");
+            }
             double secondsPerDay = GameSettings.KERBIN_TIME ? 21600.0 : 86400.0;
             float scienceRatePerDay = (float)(secondsPerDay * totalScientistLevel * dataStored * dataProcessingMultiplier * scienceMultiplier) / Mathf.Pow(10f, researchTime);
             DebugLog($"[AutomaticLabHousekeeper] scienceRatePerDay {scienceRatePerDay}");
@@ -394,6 +408,48 @@ namespace ALH
 
             return Mathf.Max(totalScientistLevel, 0.0f); // If no scientists, processing stops
         }
+
+        float GetAIScientistsLevel(Vessel vessel, ProtoPartSnapshot converterPart, float scientistBonus)
+        {
+            float totalLevel = 0f;
+
+            // Find the parent index of the converter part
+            int parentIndex = converterPart.parentIdx;
+            if (parentIndex < 0 || parentIndex >= vessel.protoVessel.protoPartSnapshots.Count)
+                return 0f;
+
+            // Converter part's parent
+            ProtoPartSnapshot parentPart = vessel.protoVessel.protoPartSnapshots[parentIndex];
+
+            // All chips with this parent
+            var chips = vessel.protoVessel.protoPartSnapshots
+                .Where(p => p.parentIdx == parentIndex);
+
+            foreach (var chip in chips)
+            {
+                foreach (var module in chip.modules)
+                {
+                    if (module.moduleName == "CW_AIScientists")
+                    {
+                        bool isActive = false;
+                        float level = 0f;
+
+                        if (module.moduleValues.HasValue("isActive"))
+                            bool.TryParse(module.moduleValues.GetValue("isActive"), out isActive);
+
+                        if (module.moduleValues.HasValue("level"))
+                            float.TryParse(module.moduleValues.GetValue("level"), out level);
+
+                        if (isActive)
+                        {
+                            DebugLog($"[AutomaticLabHousekeeper] Found active AI Scientist on {chip.partName}, level {level}");
+                            totalLevel += (1.0f + scientistBonus * level);
+                        }
+                    }
+                }
+            }
+            return Mathf.Max(totalLevel, 0.0f);
+    }
 
         void PullDataIntoLab(Vessel vessel, Part part, Module_AutomaticLabHousekeeper alhModule)
         {


### PR DESCRIPTION
As I was contributing to ALH, I was also working on a fork of ChromaWorks.
I’ve long wanted to make this mod’s parts fully usable.

ChromaWorks provides a set of chips to create your own remote probe with custom capabilities.
One of these capabilities is a “data analyzer,” which is essentially a small, uncrewed lab.

The problem is that the stock ModuleScienceConverter requires scientists onboard to generate science.

I created a new ScienceConverter module, CW_ModuleScienceConverter, inheriting from the stock module.
This module overrides the GetScientists() method to detect “CW AI Scientists” chips attached to the same parent (the probe core). This mechanism allows users to make the lab more efficient by adding “virtual” scientists.

Since I really appreciate your mod, I prepared this patch (originally for my personal use) to make ALH compatible with this new virtual ScienceConverter.

I leave it to you to decide whether to integrate it into your repository. At the moment, I am the only one using my ChromaWorks fork, but having ALH compatible with it shouldn’t hurt anyone.

Cheers,
Nok