### PR TITLE
Implement EC checks for science Transfers

### DIFF
--- a/GameData/AutomaticLabHousekeeper/Localization/de_de.cfg
+++ b/GameData/AutomaticLabHousekeeper/Localization/de_de.cfg
@@ -7,6 +7,7 @@ Localization
 		
 		//Angezeigte Nachricht
 		#autoLOC_ALH_0003 = F&E : <<1>> Wissenschaft erhalten von <<2>>
+                #autoLOC_ALH_0031 = F&E: nzureichende elektrische Energie (<<2>>/<<1>>) auf <<3>>. Wird übersprungen…
 
                 //VAB/SPH Beschreibung
                 #autoLOC_ALH_0004 = Hat die Fähigkeit automatisch Wissenschaft an F&E zu senden.\n

--- a/GameData/AutomaticLabHousekeeper/Localization/en_us.cfg
+++ b/GameData/AutomaticLabHousekeeper/Localization/en_us.cfg
@@ -7,6 +7,7 @@ Localization
 		
 		//Transmission ScreenMessage
 		#autoLOC_ALH_0003 = R&D: Received <<1>> science from <<2>>
+                #autoLOC_ALH_0031 = R&D: Insufficient EC (<<2>>/<<1>>) on <<3>>. Skipping transfer..
 
                 //VAB/SPH Description
                 #autoLOC_ALH_0004 = Has ability to automatically transfer processed science to R&D over time.\n


### PR DESCRIPTION
Save and use EC per MIT for science transfers

- Store the calculated ecPerMit value in the ALH module on loaded vessels.
- Retrieve ecPerMit during science transfer (loaded and unloaded) to accurately estimate required ElectricCharge.
- Ensures consistent energy checks across loaded and unloaded vessels for efficient science transmission.
- Consume EC on loaded vessels when transmissions occurs
- Check unloaded vessels has enough EC for transmissions (cannot consume EC on unloaded)

Logs of different use-cases

Before loading vessel, ecpermit fallback to -1 (disabled).
```
[LOG 09:49:35.681] [AutomaticLabHousekeeper] ============================================================
[LOG 09:49:35.681] [AutomaticLabHousekeeper] Processing vessel: Korbital
[LOG 09:49:35.681] [AutomaticLabHousekeeper] Simulating Science for Unloaded Lab in Vessel Korbital
[LOG 09:49:35.681] [AutomaticLabHousekeeper] dataStored 996.75
[LOG 09:49:35.681] [AutomaticLabHousekeeper] storedScience 28.95
[LOG 09:49:35.681] [AutomaticLabHousekeeper] isActivated True
[LOG 09:49:35.681] [AutomaticLabHousekeeper] scienceCap 400
[LOG 09:49:35.681] [AutomaticLabHousekeeper] dataProcessingMultiplier 0.3
[LOG 09:49:35.681] [AutomaticLabHousekeeper] scientistBonus 0.25
[LOG 09:49:35.681] [AutomaticLabHousekeeper] researchTime 7
[LOG 09:49:35.681] [AutomaticLabHousekeeper] scienceMultiplier 5
[LOG 09:49:35.681] [AutomaticLabHousekeeper] lastUpdateTime 9481805.10210715
[LOG 09:49:35.681] [AutomaticLabHousekeeper] Detected scientist Timble Kerman with stars 2
[LOG 09:49:35.681] [AutomaticLabHousekeeper] Detected scientist Timrode Kerman with stars 2
[LOG 09:49:35.681] [AutomaticLabHousekeeper] ModuleScienceConverter détecté, totalAIScientistLevel calculé : 3
[LOG 09:49:35.681] [AutomaticLabHousekeeper] scienceRatePerDay 9.688411
[LOG 09:49:35.681] [AutomaticLabHousekeeper] scienceRate 0.0004485375
[LOG 09:49:35.681] [AutomaticLabHousekeeper] scienceGenerated 4.476322
[LOG 09:49:35.681] [AutomaticLabHousekeeper] dataUsed 0.8952644
[LOG 09:49:35.681] [AutomaticLabHousekeeper] newStoredScience 33.42632
[LOG 09:49:35.681] [AutomaticLabHousekeeper] Simulated 4.476322 science for Korbital (Data remaining: 995.8547, Stored Science: 33.42632, Total Scientist Level: 3)
[LOG 09:49:35.681] [AutomaticLabHousekeeper] Processing science transfer for lab sspx-science-1875-1 in UNLOADED vessel Korbital
[WRN 09:49:35.681] [AutomaticLabHousekeeper] GetECPerMit called with unknown alhModule type. Using fallback EC per Mit = -1
[WRN 09:49:35.681] [AutomaticLabHousekeeper] Invalid ecPerMit value (-1) in ALH module on sspx-science-1875-1. Skipping science transfer.
[LOG 09:49:35.681] [AutomaticLabHousekeeper] Attempting data pull for unloaded lab sspx-science-1875-1 on-board Korbital...
============================================================
```

After loading vessel, ecPerMit is estimated and saved. (LOADED)
```
[LOG 08:42:21.476] [AutomaticLabHousekeeper] ============================================================
[LOG 09:57:24.003] [AutomaticLabHousekeeper] Processing vessel: Discovery
[LOG 09:57:24.003] [AutomaticLabHousekeeper] Processing science transfer for lab Part in LOADED vessel Discovery
[LOG 09:57:24.004] [AutomaticLabHousekeeper] Sufficient EC (2712.0 / 30.0) for science transfer on Discovery
[LOG 09:57:24.005] [AutomaticLabHousekeeper] Consumed 30.00 EC for transmitting 5 science from Discovery
[LOG 09:57:24.005] [AutomaticLabHousekeeper] Transferring 5 science from Discovery to R&D, keeping 0.2119436 science in the lab
[LOG 09:57:24.007] [AutomaticLabHousekeeper] Attempting data pull for loaded lab compChip.lab on-board Discovery...
[LOG 09:57:24.007] [AutomaticLabHousekeeper] No experiments available or lab is full.
============================================================
```

After unloading vessel, ecPerMit is retrieved and used for EC check.
```
[LOG 09:49:35.667] [AutomaticLabHousekeeper] ============================================================
[LOG 09:49:35.667] [AutomaticLabHousekeeper] Processing vessel: Discovery
[LOG 09:49:35.667] [AutomaticLabHousekeeper] Simulating Science for Unloaded Lab in Vessel Discovery
[LOG 09:49:35.667] [AutomaticLabHousekeeper] dataStored 566.7126
[LOG 09:49:35.667] [AutomaticLabHousekeeper] storedScience 2.527113
[LOG 09:49:35.667] [AutomaticLabHousekeeper] isActivated True
[LOG 09:49:35.668] [AutomaticLabHousekeeper] scienceCap 1000
[LOG 09:49:35.668] [AutomaticLabHousekeeper] dataProcessingMultiplier 0.5
[LOG 09:49:35.668] [AutomaticLabHousekeeper] scientistBonus 0.5
[LOG 09:49:35.668] [AutomaticLabHousekeeper] researchTime 7
[LOG 09:49:35.668] [AutomaticLabHousekeeper] scienceMultiplier 5
[LOG 09:49:35.668] [AutomaticLabHousekeeper] lastUpdateTime 9491784.87858155
[LOG 09:49:35.670] [AutomaticLabHousekeeper] Found active AI Scientist on compChip.lab, level 1
[LOG 09:49:35.671] [AutomaticLabHousekeeper] CW_ModuleScienceConverter détecté, totalScientistLevel : 1.5
[LOG 09:49:35.671] [AutomaticLabHousekeeper] scienceRatePerDay 4.590372
[LOG 09:49:35.671] [AutomaticLabHousekeeper] scienceRate 0.0002125172
[LOG 09:49:35.671] [AutomaticLabHousekeeper] scienceGenerated 8.50069E-06
[LOG 09:49:35.671] [AutomaticLabHousekeeper] dataUsed 1.700138E-06
[LOG 09:49:35.671] [AutomaticLabHousekeeper] newStoredScience 2.527122
[LOG 09:49:35.671] [AutomaticLabHousekeeper] Simulated 8.50069E-06 science for Discovery (Data remaining: 566.7126, Stored Science: 2.527122, Total Scientist Level: 1.5)
[LOG 09:49:35.671] [AutomaticLabHousekeeper] Processing science transfer for lab compChip.lab in UNLOADED vessel Discovery
[LOG 09:49:35.675] [AutomaticLabHousekeeper] Sufficient EC (2730.0 / 12.0) for science transfer on Discovery (UNLOADED)
[LOG 09:49:35.675] [AutomaticLabHousekeeper] Transferring 2 science from Discovery to R&D, keeping 0.53 science in the lab
[LOG 09:49:35.680] [AutomaticLabHousekeeper] Attempting data pull for unloaded lab compChip.lab on-board Discovery...
[LOG 09:49:35.680] [AutomaticLabHousekeeper] No stored experiments in compCore
[LOG 08:43:34.032] [AutomaticLabHousekeeper] ============================================================
```

Unsufficient EC for transfer, transfer skipped (LOADED).
```
[LOG 10:01:30.280] [AutomaticLabHousekeeper] ============================================================
[LOG 10:01:30.280] [AutomaticLabHousekeeper] Processing vessel: CWtest-LowBattery
[LOG 10:01:30.280] [AutomaticLabHousekeeper] Processing science transfer for lab Part in LOADED vessel CWtest-LowBattery
[LOG 10:01:30.281] [AutomaticLabHousekeeper] Not enough EC (50.0 / 84.0) for science transfer on CWtest-LowBattery
```

Unsufficient EC for transfer, transfer skipped (UNLOADED).
```
[LOG 10:04:08.586] [AutomaticLabHousekeeper] ============================================================
[LOG 10:04:08.586] [AutomaticLabHousekeeper] Processing vessel: CWtest-LowBattery
[LOG 10:04:08.586] [AutomaticLabHousekeeper] Simulating Science for Unloaded Lab in Vessel CWtest-LowBattery
[LOG 10:04:08.586] [AutomaticLabHousekeeper] dataStored 373.7864
[LOG 10:04:08.586] [AutomaticLabHousekeeper] storedScience 26.20825
[LOG 10:04:08.586] [AutomaticLabHousekeeper] isActivated True
[LOG 10:04:08.587] [AutomaticLabHousekeeper] scienceCap 1000
[LOG 10:04:08.587] [AutomaticLabHousekeeper] dataProcessingMultiplier 0.5
[LOG 10:04:08.587] [AutomaticLabHousekeeper] scientistBonus 0.5
[LOG 10:04:08.587] [AutomaticLabHousekeeper] researchTime 7
[LOG 10:04:08.587] [AutomaticLabHousekeeper] scienceMultiplier 5
[LOG 10:04:08.587] [AutomaticLabHousekeeper] lastUpdateTime 9561709.8172944
[LOG 10:04:08.587] [AutomaticLabHousekeeper] Found active AI Scientist on compChip.lab, level 1
[LOG 10:04:08.587] [AutomaticLabHousekeeper] Found active AI Scientist on compChip.AIScientists, level 1
[LOG 10:04:08.587] [AutomaticLabHousekeeper] Found active AI Scientist on compChip.AIScientists, level 1
[LOG 10:04:08.588] [AutomaticLabHousekeeper] Found active AI Scientist on compChip.AIScientists, level 1
[LOG 10:04:08.588] [AutomaticLabHousekeeper] Found active AI Scientist on compChip.AIScientists, level 1
[LOG 10:04:08.588] [AutomaticLabHousekeeper] Found active AI Scientist on compChip.AIScientists, level 1
[LOG 10:04:08.588] [AutomaticLabHousekeeper] CW_ModuleScienceConverter détecté, totalScientistLevel : 9
[LOG 10:04:08.588] [AutomaticLabHousekeeper] scienceRatePerDay 18.16602
[LOG 10:04:08.588] [AutomaticLabHousekeeper] scienceRate 0.0008410194
[LOG 10:04:08.588] [AutomaticLabHousekeeper] scienceGenerated 0
[LOG 10:04:08.588] [AutomaticLabHousekeeper] dataUsed 0
[LOG 10:04:08.589] [AutomaticLabHousekeeper] newStoredScience 26.20825
[LOG 10:04:08.589] [AutomaticLabHousekeeper] Simulated 0 science for CWtest-LowBattery (Data remaining: 373.7864, Stored Science: 26.20825, Total Scientist Level: 9)
[LOG 10:04:08.589] [AutomaticLabHousekeeper] Processing science transfer for lab compChip.lab in UNLOADED vessel CWtest-LowBattery
[LOG 10:04:08.590] [AutomaticLabHousekeeper] Not enough EC (50.0 / 156.0) for science transfer on CWtest-LowBattery (UNLOADED)
```